### PR TITLE
Update Publish() call for change in API

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -53,7 +53,7 @@ func (ph *pubSubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := context.Background()
 	msgIDs, err := topic.Publish(ctx, &pubsub.Message{
 		Data: data,
-	})
+	}).Get(ctx)
 
 	childSpan.Finish()
 


### PR DESCRIPTION
Publish() now returns a future.
See https://godoc.org/cloud.google.com/go/pubsub